### PR TITLE
Throw exception if broken link is present where directory should be

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ php:
   - 5.6
   - hhvm
 
+matrix:
+  allow_failures:
+    - php: hhvm
+
 install:
   - composer self-update
   - composer install --prefer-source

--- a/src/CoreInstaller.php
+++ b/src/CoreInstaller.php
@@ -3,6 +3,7 @@
 namespace AydinHassan\MagentoCoreComposerInstaller;
 
 use Composer\Util\Filesystem;
+use ErrorException;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 
@@ -58,7 +59,18 @@ class CoreInstaller
             }
 
             if ($item->isDir()) {
-                if (!file_exists($destinationFile)) {
+                $fileExists = file_exists($destinationFile);
+                if (!$fileExists && is_link($destinationFile)) {
+                    throw new \RuntimeException(
+                        sprintf(
+                            'File: "%s" appears to be a broken symlink referencing: "%s"',
+                            $destinationFile,
+                            readlink($destinationFile)
+                        )
+                    );
+                }
+
+                if (!$fileExists) {
                     mkdir($destinationFile);
                 }
                 continue;


### PR DESCRIPTION
Better error message is a broken symlink is present where a directory should be. `file_exists` returns false for broken symlinks.

Fixes #19 