### PR TITLE
Add 'magento-core-package-name' option

### DIFF
--- a/src/CoreManager.php
+++ b/src/CoreManager.php
@@ -128,7 +128,7 @@ class CoreManager implements PluginInterface, EventSubscriberInterface
     {
         $installedCorePackages = array();
         foreach ($event->getInstalledRepo()->getPackages() as $package) {
-            if ($package->getType() === $this->type) {
+            if ($this->packageIsMagentoCore($package)) {
                 $installedCorePackages[$package->getName()] = $package;
             }
         }
@@ -139,7 +139,7 @@ class CoreManager implements PluginInterface, EventSubscriberInterface
 
         foreach ($operations as $operation) {
             $p = $operation->getPackage();
-            if ($p->getType() === $this->type) {
+            if ($this->packageIsMagentoCore($p)) {
                 switch ($operation->getJobType()) {
                     case "uninstall":
                         unset($installedCorePackages[$p->getName()]);
@@ -171,7 +171,7 @@ class CoreManager implements PluginInterface, EventSubscriberInterface
                 break;
         }
 
-        if ($package->getType() === $this->type) {
+        if ($this->packageIsMagentoCore($package)) {
             $options = new Options($this->composer->getPackage()->getExtra());
             $this->ensureRootDirExists($options);
 
@@ -204,7 +204,7 @@ class CoreManager implements PluginInterface, EventSubscriberInterface
                 break;
         }
 
-        if ($package->getType() === $this->type) {
+        if ($this->packageIsMagentoCore($package)) {
 
             $options = new Options($this->composer->getPackage()->getExtra());
 
@@ -223,6 +223,16 @@ class CoreManager implements PluginInterface, EventSubscriberInterface
         }
     }
 
+    protected function packageIsMagentoCore(PackageInterface $package)
+    {
+        $options = new Options($this->composer->getPackage()->getExtra());
+        if ($name = $options->getMagentoCorePackageName()) {
+            return ($package->getName() === $name);
+        } else {
+            return ($package->getType() === $this->type);
+        }
+    }
+
 
     /**
      * Create root directory if it doesn't exist already
@@ -238,6 +248,7 @@ class CoreManager implements PluginInterface, EventSubscriberInterface
 
     /**
      * @param Options $options
+     * @return CoreInstaller
      */
     public function getInstaller(Options $options)
     {

--- a/src/Options.php
+++ b/src/Options.php
@@ -126,6 +126,13 @@ class Options
     protected $magentoRootDir;
 
     /**
+     * Name of Magento Core Package
+     *
+     * @var string
+     */
+    protected $magentoCorePackageName;
+
+    /**
      * @param array $packageExtra
      */
     public function __construct(array $packageExtra)
@@ -161,6 +168,10 @@ class Options
             throw new \InvalidArgumentException("magento-root-dir must be specified in root package");
         }
 
+        if (isset($packageExtra['magento-core-package-name'])) {
+            $this->magentoCorePackageName = $packageExtra['magento-core-package-name'];
+        }
+
         $this->magentoRootDir = rtrim($packageExtra['magento-root-dir'], "/");
     }
 
@@ -194,5 +205,13 @@ class Options
     public function getMagentoRootDir()
     {
         return $this->magentoRootDir;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMagentoCorePackageName()
+    {
+        return $this->magentoCorePackageName;
     }
 }


### PR DESCRIPTION
Add an option called 'magento-core-package-name'. If this is present, it will be used to identify the Magento core package rather than the package type.

e.g. OpenMage/magento-lts has a package type of 'magento-source' rather than 'magento-core'