### PR TITLE
Add ability to suppress gitignore functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Available configuration
  * `excludes` - An array of files to not copy when installing the core, useful if local overrides are necessary, or you want to track a `.htaccess`.
  * `ignore-directories` - An array of folders to group ignores together to make the core `.gitignore` smaller.
  * `git-ignore-append` - Defaults to `true`. Whether to append to the `.gitignore` in the `magento-root-dir` folder. If false it will be wiped out on each deploy.
- 
+ * `git-ignore-enable` - Defaults to `true`. Setting this to `false` will prevent any actions being taken on the `.gitignore` file in the `magento-root-dir` folder.
+
 Example configuration:
 
     {

--- a/src/CoreManager.php
+++ b/src/CoreManager.php
@@ -240,7 +240,8 @@ class CoreManager implements PluginInterface, EventSubscriberInterface
         $gitIgnore = new GitIgnore(
             sprintf("%s/.gitignore", $options->getMagentoRootDir()),
             $options->getIgnoreDirectories(),
-            $options->appendToGitIgnore()
+            $options->appendToGitIgnore(),
+            $options->gitIgnoreFunctionalityEnabled()
         );
 
         $installer = new CoreInstaller($exclude, $gitIgnore, $this->filesystem);

--- a/src/GitIgnore.php
+++ b/src/GitIgnore.php
@@ -31,13 +31,25 @@ class GitIgnore
     protected $hasChanges = false;
 
     /**
+     * @var bool
+     */
+    protected $gitIgnoreEnabled;
+
+    /**
      * @param string $fileLocation
      * @param array $directoriesToIgnoreEntirely
      * @param bool $gitIgnoreAppend
+     * @param bool $gitIgnoreEnabled
      */
-    public function __construct($fileLocation, array $directoriesToIgnoreEntirely, $gitIgnoreAppend = true)
-    {
+    public function __construct(
+        $fileLocation,
+        array $directoriesToIgnoreEntirely,
+        $gitIgnoreAppend = true,
+        $gitIgnoreEnabled = true
+    ) {
         $this->gitIgnoreLocation = $fileLocation;
+
+        $this->gitIgnoreEnabled = $gitIgnoreEnabled;
 
         if (file_exists($fileLocation) && $gitIgnoreAppend) {
             $this->lines = explode("\n", file_get_contents($fileLocation));
@@ -112,7 +124,7 @@ class GitIgnore
      */
     public function __destruct()
     {
-        if ($this->hasChanges) {
+        if ($this->gitIgnoreEnabled && $this->hasChanges) {
             file_put_contents($this->gitIgnoreLocation, implode("\n", $this->lines));
         }
     }

--- a/src/Options.php
+++ b/src/Options.php
@@ -119,6 +119,13 @@ class Options
     protected $appendToGitIgnore = true;
 
     /**
+     * Whether the git ignore functionality is enabled
+     *
+     * @var bool
+     */
+    protected $gitIgnoreFunctionalityEnabled = true;
+
+    /**
      * Magento Root Directory
      *
      * @var string
@@ -160,6 +167,10 @@ class Options
             $this->ignoreDirectories = $coreInstallerOptions['ignore-directories'];
         }
 
+        if (isset($coreInstallerOptions['git-ignore-enable'])) {
+            $this->gitIgnoreFunctionalityEnabled = (bool) $coreInstallerOptions['git-ignore-enable'];
+        }
+
         if (isset($coreInstallerOptions['git-ignore-append'])) {
             $this->appendToGitIgnore = (bool) $coreInstallerOptions['git-ignore-append'];
         }
@@ -189,6 +200,14 @@ class Options
     public function getIgnoreDirectories()
     {
         return $this->ignoreDirectories;
+    }
+
+    /**
+     * @return bool
+     */
+    public function gitIgnoreFunctionalityEnabled()
+    {
+        return $this->gitIgnoreFunctionalityEnabled;
     }
 
     /**

--- a/test/GitIgnoreTest.php
+++ b/test/GitIgnoreTest.php
@@ -29,6 +29,15 @@ class GitIgnoreTest extends \PHPUnit_Framework_TestCase
         $this->assertFileExists($this->gitIgnoreFile);
     }
 
+    public function testIfFileNotExistsItIsNotCreated()
+    {
+        $gitIgnore = new GitIgnore($this->gitIgnoreFile, array(), true, false);
+        $gitIgnore->addEntry("file1");
+        unset($gitIgnore);
+
+        $this->assertFileNotExists($this->gitIgnoreFile);
+    }
+
     public function testIfFileExistsExistingLinesAreLoaded()
     {
         $lines = array('line1', 'line2');


### PR DESCRIPTION
I do not want this module to handle the `.gitignore` in any way for my instance.

I have added an option so that I can add the following to my `composer.json` to use this functionality.

```
    "magento-core-deploy": {
      "git-ignore-enable": false,
```

It's backwards compatible as the default option is to generate the gitignore.

I'll be using our fork of your module for the time being, see here: https://github.com/AmpersandHQ/magento-core-composer-installer/releases/tag/1.4.0-patch2